### PR TITLE
Allow CloudFormation !Expressions to be merged

### DIFF
--- a/cfn_review_bot/loader.py
+++ b/cfn_review_bot/loader.py
@@ -54,6 +54,11 @@ class OpaqueTagValue:
         self.tag = tag
         self.value = value
 
+    def __eq__(self, other):
+        if self.__class__ == other.__class__:
+            return (self.tag == other.tag) and (self.value == other.value)
+        return NotImplemented
+
 
 class OpaqueTagMapping(OpaqueTagValue):
     pass


### PR DESCRIPTION
... as long as they're the same expression.